### PR TITLE
Change references to rtnpro@redhat.com

### DIFF
--- a/index.d/centos.yml
+++ b/index.d/centos.yml
@@ -7,7 +7,7 @@ Projects:
     git-path: kubernetes/master
     target-file: Dockerfile
     desired-tag: latest
-    notify-email: rtnpro@redhat.com
+    notify-email: container-status-report@centos.org
     depends-on: centos/centos:latest
 
   - id: 26
@@ -18,7 +18,7 @@ Projects:
     git-path: kubernetes/apiserver
     target-file: Dockerfile
     desired-tag: latest
-    notify-email: rtnpro@redhat.com
+    notify-email: container-status-report@centos.org
     depends-on: 
       - centos/centos:latest
       - centos/kubernetes-master:latest


### PR DESCRIPTION
Replace email address with team alias. We're already working on using a different branch of upstream container-index repo to do tests. But, in the interim, if you can merge this, it would be helpful!